### PR TITLE
Add `packaging` to dependencies.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - dataclasses  # [py == 36]
     - contextvars  # [py == 36]
+    - packaging
     - tiledb 2.6.*
 
 {% if python_impl != 'pypy' %}


### PR DESCRIPTION
`packaging` is specified as a dependency in the PyPI package,
but was not included in the dependency list of the Conda package.
This meant that using `.from_pandas` or `.to_pandas` could break
if the user did not have `packaging` installed from some other dep.