### PR TITLE
Build tiledb-py 0.22.0 for Python 3.7

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -69,7 +69,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win32]
   skip: true  # [win and py2k]
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
+    - cython <3.0                            # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
   host:
@@ -29,7 +29,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - python
-    - cython
+    - cython <3.0
     - numpy
     - pybind11
     - tiledb >=2.16.0,<2.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython <3.0                            # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
+    - pybind11 <2.11                         # [build_platform != target_platform]
   host:
     - pip
     - wheel
@@ -31,7 +31,7 @@ requirements:
     - python
     - cython <3.0
     - numpy
-    - pybind11
+    - pybind11 <2.11
     - tiledb >=2.16.0,<2.17
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledb" %}
-{% set version = "0.21.6" %}
-{% set sha256 = "f787617385de6b5391fef0c52e665b790ab1cb1fcc1cf78616b7134aebb86410" %}
+{% set version = "0.22.0" %}
+{% set sha256 = "ad31527687526702d869ed8015bd0c20dc5d6c871222c3bdb92c34773046fe0e" %}
 
 package:
   name: tiledb-py
@@ -32,7 +32,7 @@ requirements:
     - cython
     - numpy
     - pybind11
-    - tiledb >=2.15.1,<2.16
+    - tiledb >=2.16.0,<2.17
   run:
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
@Shelnutt2 @ihnorton @johnkerl

Long-term I want to automate this, but for now we need tiledb-py 0.22.0 built for Python 3.7 so that we can test tiledbsoma-py 1.3.0 in https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/34

To create this PR, I simply merged "main" into Seth's existing branch [ss/re-enable-python3.7](https://github.com/TileDB-Inc/tiledb-py-feedstock/tree/ss/re-enable-python3.7). I reset the build number because we only need to upload new binaries for Python 3.7. Also, I rerendered, but no changes needed to be made